### PR TITLE
Die operation description

### DIFF
--- a/src/diceRoller.ts
+++ b/src/diceRoller.ts
@@ -607,13 +607,13 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
-					const newRoll = this.reRoll(rolls[i], ++i);
+					const newRoll = this.reRoll(roll,i+1);
 					rollValue += newRoll.roll;
 					roll = newRoll;
 				}
 
-				roll.value = rollValue;
-				roll.roll = rollValue;
+				rolls[i].value = rollValue;
+				rolls[i].roll = rollValue;
 			}
 
 			return rolls;

--- a/src/diceRoller.ts
+++ b/src/diceRoller.ts
@@ -514,7 +514,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
-					rolls[i].operation = 'drop'
+					rolls[i].drop = true
 					dropped++;
 				}
 
@@ -540,7 +540,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
-					rolls[i].operation = 'drop'
+					rolls[i].drop = true
 					dropped++;
 				}
 
@@ -575,7 +575,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
-					roll.operation = 'explode'
+					roll.explode = true
 					const newRoll = this.reRoll(roll, ++i);
 					rolls.splice(i, 0, newRoll);
 					roll = newRoll;
@@ -610,7 +610,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
-					roll.operation = 'explode'
+					roll.explode = true
 					const newRoll = this.reRoll(roll,i+1);
 					rollValue += newRoll.roll;
 					roll = newRoll;
@@ -648,7 +648,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
-					roll.operation = 'explode'
+					roll.explode = true
 					const newRoll = this.reRoll(roll, ++i);
 					newRoll.value -= 1;
 					newRoll.roll -= 1;
@@ -673,7 +673,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				while (targetMethod(rolls[i].roll)) {
-					rolls[i].operation = 'reroll'
+					rolls[i].reroll = true
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);
@@ -696,7 +696,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				if (targetMethod(rolls[i].roll)) {
-					rolls[i].operation = 'reroll'
+					rolls[i].reroll = true
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);

--- a/src/diceRoller.ts
+++ b/src/diceRoller.ts
@@ -514,6 +514,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
+					rolls[i].operation = 'drop'
 					dropped++;
 				}
 
@@ -539,6 +540,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
+					rolls[i].operation = 'drop'
 					dropped++;
 				}
 
@@ -573,6 +575,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll, ++i);
 					rolls.splice(i, 0, newRoll);
 					roll = newRoll;
@@ -607,6 +610,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll,i+1);
 					rollValue += newRoll.roll;
 					roll = newRoll;
@@ -644,6 +648,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll, ++i);
 					newRoll.value -= 1;
 					newRoll.roll -= 1;
@@ -668,6 +673,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				while (targetMethod(rolls[i].roll)) {
+					rolls[i].operation = 'reroll'
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);
@@ -690,6 +696,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				if (targetMethod(rolls[i].roll)) {
+					rolls[i].operation = 'reroll'
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);

--- a/src/rollTypes.ts
+++ b/src/rollTypes.ts
@@ -28,6 +28,8 @@ export interface RollBase {
 	label?: string;
 	/** A property used to maintain ordering of dice rolls within groups */
 	order: number;
+	/** Any special operations appied to this die */
+	operation?: string;
 }
 
 /** An intermediate interface extended for groups of dice */

--- a/src/rollTypes.ts
+++ b/src/rollTypes.ts
@@ -28,8 +28,12 @@ export interface RollBase {
 	label?: string;
 	/** A property used to maintain ordering of dice rolls within groups */
 	order: number;
-	/** Any special operations appied to this die */
-	operation?: string;
+	/** Has this die been dropped */
+	drop?: boolean;
+	/** Has this die exploded */
+	explode?: boolean;
+	/** Has this die been rerolled */
+	reroll?: boolean;
 }
 
 /** An intermediate interface extended for groups of dice */

--- a/test/rollerTest.test.ts
+++ b/test/rollerTest.test.ts
@@ -63,3 +63,27 @@ testRolls.forEach(([roll, expectedValue]) => {
 		expect(roller.rollValue(roll)).toBe(expectedValue)
 	});
 });
+
+const testFixedRolls: [string, number, number[]][] = [
+	['1d6!!', 14, [.84, .84, .17]], // value = [6,6,2]
+	['4d6!!', 24, [.84, .67, .5, .17, .84, 0]] // value = [6,5,4,2,6,1]
+]
+
+let externalCount: number = 0
+let rollsAsFloats: Array<number> = []
+const fixedRoller = new dist.DiceRoller((rolls: Array<number> = rollsAsFloats)=>{
+	if(rolls.length > 0) {
+		return rolls[externalCount++]
+	} else {
+		console.warn("No results passed to the dice-roller-parser. Using fallback Math.random")
+		return Math.random()
+	}
+})
+
+testFixedRolls.forEach(([roll, expectedValue, values]) => {
+	test(roll, () => {
+		externalCount = 0
+		rollsAsFloats = values
+		expect(fixedRoller.rollValue(roll)).toBe(expectedValue)
+	});
+});

--- a/test/rollerTest.test.ts
+++ b/test/rollerTest.test.ts
@@ -66,7 +66,8 @@ testRolls.forEach(([roll, expectedValue]) => {
 
 const testFixedRolls: [string, number, number[]][] = [
 	['1d6!!', 14, [.84, .84, .17]], // value = [6,6,2]
-	['4d6!!', 24, [.84, .67, .5, .17, .84, 0]] // value = [6,5,4,2,6,1]
+	['4d6!!', 24, [.84, .67, .5, .17, .84, 0]], // value = [6,5,4,2,6,1]
+	['4d6dl1', 15, [.84, .67, .5, .17]] // value = [6,5,4,2]
 ]
 
 let externalCount: number = 0


### PR DESCRIPTION
Adding an additional `operation` property descriptor to `RollBase` die objects. This will easily flag dice as 'drop', 'reroll' and 'explode'.

Use Case: After getting the final roll results, I'd like to mark which dice have been dropped, rerolled, or exploded. For example, when rolling `4d6dl1`. Using the `valid` property doesn't always explain why a die may have been invalidated. Also, a dice that is `critical: "success` doesn't always explode. This new property will help to clear that up for post-processing.